### PR TITLE
Split on dots without whitespace to properly return packages XXX.YYY when searching YY

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Stop SonarScanner and send analysis
       run: |
         export JAVA_HOME=$JAVA_HOME_17_X64 # Force JAVA_HOME environment variable (Version 11 or 17 is required by SonarScanner)
-        dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+        dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
   keepalive:
     name: Keepalive Workflow


### PR DESCRIPTION
Fix https://github.com/ScoopInstaller/scoopinstaller.github.io/issues/107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced search indexing to better handle search terms containing dots by treating them as word separators during tokenization.

* **Chores**
  * Updated authentication configuration in CI/CD workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->