### PR TITLE
Record bucket names in manifest metadata for official buckets

### DIFF
--- a/src/ScoopSearch.Indexer.Tests/Buckets/Sources/OfficialBucketsSourceTests.cs
+++ b/src/ScoopSearch.Indexer.Tests/Buckets/Sources/OfficialBucketsSourceTests.cs
@@ -89,7 +89,7 @@ public class OfficialBucketsSourceTests
 
     [Theory]
     [MemberData(nameof(GetBucketsAsyncTestCases))]
-    public async Task GetBucketsAsync_Succeeds(string content, string repositoryUri, bool isCompatible, bool expectedBucket)
+    public async Task GetBucketsAsync_Succeeds(string content, string repositoryUri, bool isCompatible, bool expectedBucket, string? expectedName = null)
     {
         // Arrange
         _bucketsOptions.OfficialBucketsListUrl = Faker.CreateUri();
@@ -115,18 +115,19 @@ public class OfficialBucketsSourceTests
         result.Should().HaveCount(expectedBucket ? 1 : 0);
         if (expectedBucket)
         {
-            result.Should().BeEquivalentTo(new[] { bucket });
+            var expectedBucketObj = new Bucket(new Uri(repositoryUri), 123, expectedName);
+            result.Should().BeEquivalentTo(new[] { expectedBucketObj });
         }
     }
 
-    public static TheoryData<string, string, bool, bool> GetBucketsAsyncTestCases()
+    public static TheoryData<string, string, bool, bool, string?> GetBucketsAsyncTestCases()
     {
-        var data = new TheoryData<string, string, bool, bool>();
+        var data = new TheoryData<string, string, bool, bool, string?>();
         var url = Faker.CreateUrl();
-        data.Add($@"{{ }}", url, false, false);
-        data.Add($@"{{ }}", url, true, false);
-        data.Add($@"{{ ""foo"": ""{url}"" }}", url, false, false);
-        data.Add($@"{{ ""foo"": ""{url}"" }}", url, true, true);
+        data.Add($@"{{ }}", url, false, false, null);
+        data.Add($@"{{ }}", url, true, false, null);
+        data.Add($@"{{ ""foo"": ""{url}"" }}", url, false, false, null);
+        data.Add($@"{{ ""foo"": ""{url}"" }}", url, true, true, "foo");
 
         return data;
     }

--- a/src/ScoopSearch.Indexer.Tests/Helpers/Faker.cs
+++ b/src/ScoopSearch.Indexer.Tests/Helpers/Faker.cs
@@ -37,6 +37,7 @@ public static class Faker
             .RuleFor(_ => _.OfficialRepositoryNumber, f => f.Random.Int(0, 1))
             .RuleFor(_ => _.Repository, f => f.Internet.UrlRootedPath())
             .RuleFor(_ => _.OfficialRepository, f => f.Random.Bool())
+            .RuleFor(_ => _.OfficialRepositoryName, (f, o) => o.OfficialRepository == true ? f.Lorem.Word() : null)
             .RuleFor(_ => _.BranchName, f => f.Lorem.Word())
             .RuleFor(_ => _.FilePath, f => f.System.FilePath())
             .RuleFor(_ => _.Committed, f => f.Date.RecentOffset())
@@ -50,7 +51,8 @@ public static class Faker
         var faker = new Faker<GitHubRepo>()
             .StrictMode(true)
             .RuleFor(_ => _.HtmlUri, f => new Uri(f.Internet.Url()))
-            .RuleFor(_ => _.Stars, f => f.Random.Int(0, 1000));
+            .RuleFor(_ => _.Stars, f => f.Random.Int(0, 1000))
+            .RuleFor(_ => _.Name, f => f.Lorem.Word());
 
         return faker;
     }

--- a/src/ScoopSearch.Indexer/Buckets/Bucket.cs
+++ b/src/ScoopSearch.Indexer/Buckets/Bucket.cs
@@ -2,13 +2,16 @@
 
 public class Bucket
 {
-    public Bucket(Uri uri, int stars)
+    public Bucket(Uri uri, int stars, string? name = null)
     {
         Uri = uri;
         Stars = stars;
+        Name = name;
     }
 
     public Uri Uri { get; private set; }
 
     public int Stars { get; private set; }
+
+    public string? Name { get; private set; }
 }

--- a/src/ScoopSearch.Indexer/Buckets/Providers/GitHubBucketsProvider.cs
+++ b/src/ScoopSearch.Indexer/Buckets/Providers/GitHubBucketsProvider.cs
@@ -18,7 +18,7 @@ internal class GitHubBucketsProvider : IBucketsProvider
         var result = await _gitHubClient.GetRepositoryAsync(uri, cancellationToken);
         if (result is not null)
         {
-            return new Bucket(result.HtmlUri, result.Stars);
+            return new Bucket(result.HtmlUri, result.Stars, result.Name);
         }
 
         return null;

--- a/src/ScoopSearch.Indexer/Buckets/Sources/GitHubBucketsSource.cs
+++ b/src/ScoopSearch.Indexer/Buckets/Sources/GitHubBucketsSource.cs
@@ -34,7 +34,7 @@ internal class GitHubBucketsSource : IBucketsSource
         {
             await foreach(var repo in _gitHubClient.SearchRepositoriesAsync(query, cancellationToken))
             {
-                yield return new Bucket(repo.HtmlUri, repo.Stars);
+                yield return new Bucket(repo.HtmlUri, repo.Stars, repo.Name);
             }
         }
     }

--- a/src/ScoopSearch.Indexer/Buckets/Sources/OfficialBucketsSource.cs
+++ b/src/ScoopSearch.Indexer/Buckets/Sources/OfficialBucketsSource.cs
@@ -37,17 +37,18 @@ internal class OfficialBucketsSource : IOfficialBucketsSource
 
         _logger.LogInformation("Retrieving official buckets from {Uri}", _bucketOptions.OfficialBucketsListUrl);
 
-        await foreach (var uri in GetBucketsFromJsonAsync(_bucketOptions.OfficialBucketsListUrl, cancellationToken))
+        await foreach (var (name, uri) in GetBucketsFromJsonAsync(_bucketOptions.OfficialBucketsListUrl, cancellationToken))
         {
             var provider = _bucketsProviders.FirstOrDefault(provider => provider.IsCompatible(uri));
             if (provider is not null && await provider.GetBucketAsync(uri, cancellationToken) is { } bucket)
             {
-                yield return bucket;
+                // Create a new bucket with the official name
+                yield return new Bucket(bucket.Uri, bucket.Stars, name);
             }
         }
     }
 
-    private async IAsyncEnumerable<Uri> GetBucketsFromJsonAsync(Uri uri, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<(string Name, Uri Uri)> GetBucketsFromJsonAsync(Uri uri, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var contentJson = await _httpClientFactory.CreateDefaultClient().GetStreamAsync(uri, cancellationToken);
         var officialBuckets = await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(contentJson, cancellationToken: cancellationToken);
@@ -59,7 +60,7 @@ internal class OfficialBucketsSource : IOfficialBucketsSource
 
         foreach (var officialBucket in officialBuckets)
         {
-            yield return new Uri(officialBucket.Value);
+            yield return (officialBucket.Key, new Uri(officialBucket.Value));
         }
     }
 }

--- a/src/ScoopSearch.Indexer/Data/ManifestMetadata.cs
+++ b/src/ScoopSearch.Indexer/Data/ManifestMetadata.cs
@@ -69,11 +69,16 @@ public class ManifestMetadata
     [JsonInclude]
     public string? DuplicateOf { get; private set; }
 
-    public void SetRepositoryMetadata(bool officialRepository, int repositoryStars)
+    [SearchableField(IsFilterable = true, IsFacetable = true, AnalyzerName = AzureSearchIndex.StandardAnalyzer)]
+    [JsonInclude]
+    public string? OfficialRepositoryName { get; private set; }
+
+    public void SetRepositoryMetadata(bool officialRepository, int repositoryStars, string? officialRepositoryName = null)
     {
         OfficialRepository = officialRepository;
         OfficialRepositoryNumber = OfficialRepository.GetValueOrDefault() ? 1 : 0;
         RepositoryStars = repositoryStars;
+        OfficialRepositoryName = (officialRepository && !string.IsNullOrEmpty(officialRepositoryName)) ? officialRepositoryName : null;
     }
 
     public void SetDuplicateOf(string originalId)

--- a/src/ScoopSearch.Indexer/GitHub/GitHubRepo.cs
+++ b/src/ScoopSearch.Indexer/GitHub/GitHubRepo.cs
@@ -9,4 +9,7 @@ public class GitHubRepo
 
     [JsonInclude, JsonPropertyName("stargazers_count")]
     public int Stars { get; private set; }
+
+    [JsonInclude, JsonPropertyName("name")]
+    public string? Name { get; private set; }
 }

--- a/src/ScoopSearch.Indexer/ScoopSearchIndexer.cs
+++ b/src/ScoopSearch.Indexer/ScoopSearchIndexer.cs
@@ -70,7 +70,7 @@ internal class ScoopSearchIndexer : IScoopSearchIndexer
             var isOfficialBuckets = officialBucketsHashSet.Contains(bucket.Uri);
             await foreach (var manifest in _fetchManifestsProcessor.FetchManifestsAsync(bucket, token))
             {
-                manifest.Metadata.SetRepositoryMetadata(isOfficialBuckets, bucket.Stars);
+                manifest.Metadata.SetRepositoryMetadata(isOfficialBuckets, bucket.Stars, bucket.Name);
                 allManifests.Add(manifest);
                 manifestsCount++;
             }


### PR DESCRIPTION
Record bucket name in the manifest metadata for official bucket manifests. This eliminates the need to pull `buckets.json` from the  fronted and ensures the index is updated promptly, even when `buckets.json` changes.

Relates to https://github.com/ScoopInstaller/scoopinstaller.github.io/issues/116.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buckets now include an optional repository name to improve search, filtering, and display.
  * Indexing now captures an official repository name in package metadata for better organization and discovery.

* **Tests**
  * Unit tests and test data updated to cover repository/name handling and related metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->